### PR TITLE
enable 2-way sync with gatekeeper

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,4 +23,5 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
+      doc-automation-disabled: false
     secrets: inherit


### PR DESCRIPTION
Add a field in CI to enable docs sync to discourse with gatekeeper

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
