### PR TITLE
Update docs to remove references to k8s agent operator

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
-# Jenkins-k8s Operator
+# Jenkins-agent Operator
 
-A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators) deploying and managing [Jenkins](https://www.jenkins.io/) Agents on machines. It is configurable to integrate with a Jenkins charm deployed in another Juju model.
+A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators) deploying and managing [Jenkins](https://www.jenkins.io/) agents on machines. It is configurable to integrate with a Jenkins charm deployed in another Juju model.
 
 This charm simplifies initial deployment and "day N" operations of Jenkins Agent on VMs and bare metal.
 
 As such, the charm makes it easy for those looking to take control of their own agents whilst keeping operations simple, and gives them the freedom to deploy on the platform of their choice.
 
-For DevOps or SRE teams this charm will make operating Jenkins Agent simple and straightforward through Juju's clean interface. It will allow easy deployment into multiple environments for testing changes, and supports scaling out for enterprise deployments.
+For DevOps or SRE teams this charm will make operating Jenkins agents simple and straightforward through Juju's clean interface. It will allow easy deployment into multiple environments for testing changes, and supports scaling out for enterprise deployments.
 
 ## Project and community
 
@@ -17,7 +17,7 @@ The Jenkins-agent Operator is a member of the Ubuntu family. It's an open source
 - [Join our online chat](https://app.element.io/#/room/#charmhub-charmdev:ubuntu.com)
 - [Contribute](Contribute)
 
-Thinking about using the Jenkins-k8s Operator for your next project? [Get in touch](https://app.element.io/#/room/#charmhub-charmdev:ubuntu.com)!
+Thinking about using the Jenkins-agent Operator for your next project? [Get in touch](https://app.element.io/#/room/#charmhub-charmdev:ubuntu.com)!
 
 # Contents
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Trivial documentation updates, removing references to k8s agent operator.

### Rationale

As above

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
