### PR TITLE
Remove systemd config on relation departed

### DIFF
--- a/src/agent_observer.py
+++ b/src/agent_observer.py
@@ -93,4 +93,5 @@ class Observer(ops.Object):
         except service.ServiceStopError:
             self.charm.unit.status = ops.BlockedStatus("Error stopping the agent service")
             return
+        self.jenkins_agent_service.clear_service_configuration()
         self.charm.unit.status = ops.BlockedStatus("Waiting for config/relation.")

--- a/src/agent_observer.py
+++ b/src/agent_observer.py
@@ -89,9 +89,8 @@ class Observer(ops.Object):
     def _on_agent_relation_departed(self, _: ops.RelationDepartedEvent) -> None:
         """Handle agent relation departed event."""
         try:
-            self.jenkins_agent_service.stop()
+            self.jenkins_agent_service.reset()
         except service.ServiceStopError:
             self.charm.unit.status = ops.BlockedStatus("Error stopping the agent service")
             return
-        self.jenkins_agent_service.clear_service_configuration()
         self.charm.unit.status = ops.BlockedStatus("Waiting for config/relation.")

--- a/src/service.py
+++ b/src/service.py
@@ -176,6 +176,11 @@ class JenkinsAgentService:
             logger.error("service %s failed to stop", AGENT_SERVICE_NAME)
             raise ServiceStopError(f"service {AGENT_SERVICE_NAME} failed to stop") from exc
 
+    def clear_service_configuration(self) -> None:
+        """Clear the service's configuration file."""
+        config_file = Path(f"{SYSTEMD_SERVICE_CONF_DIR}/override.conf")
+        config_file.unlink(missing_ok=True)
+
     def _startup_check(self) -> bool:
         """Check whether the service was correctly started.
 

--- a/src/service.py
+++ b/src/service.py
@@ -164,8 +164,8 @@ class JenkinsAgentService:
         if not self._startup_check():
             raise ServiceRestartError("Error waiting for the agent service to start")
 
-    def stop(self) -> None:
-        """Stop the agent service.
+    def reset(self) -> None:
+        """Stop the agent service and clear its configuration file.
 
         Raises:
             ServiceStopError: if systemctl stop returns a non-zero exit code.
@@ -175,9 +175,6 @@ class JenkinsAgentService:
         except systemd.SystemdError as exc:
             logger.error("service %s failed to stop", AGENT_SERVICE_NAME)
             raise ServiceStopError(f"service {AGENT_SERVICE_NAME} failed to stop") from exc
-
-    def clear_service_configuration(self) -> None:
-        """Clear the service's configuration file."""
         config_file = Path(f"{SYSTEMD_SERVICE_CONF_DIR}/override.conf")
         config_file.unlink(missing_ok=True)
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import ops.testing
 import pytest
+import pathlib
 from charms.operator_libs_linux.v1 import systemd
 
 import service
@@ -141,6 +142,8 @@ def test_agent_relation_departed(
     assert: The charm falls into BlockedStatus with the correct message.
     """
     monkeypatch.setattr(systemd, "service_stop", MagicMock())
+    path_unlink_mock = MagicMock()
+    monkeypatch.setattr(pathlib.Path, "unlink", path_unlink_mock)
 
     harness = harness_with_agent_relation
     harness.begin()
@@ -152,3 +155,4 @@ def test_agent_relation_departed(
     charm: JenkinsAgentCharm = harness.charm
     assert charm.unit.status.name == ops.BlockedStatus.name
     assert charm.unit.status.message == "Waiting for config/relation."
+    path_unlink_mock.assert_called_once()

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -5,11 +5,11 @@
 
 """Test for agent relations."""
 
+import pathlib
 from unittest.mock import MagicMock, PropertyMock
 
 import ops.testing
 import pytest
-import pathlib
 from charms.operator_libs_linux.v1 import systemd
 
 import service


### PR DESCRIPTION
When agent relation is removed the systemd config file is not removed, we should clean it up after stopping the service

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
