### PR TITLE
Bump package version to 1.0.5 which includes logic to clean up health check file

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -18,7 +18,7 @@ from charm_state import State
 logger = logging.getLogger(__name__)
 AGENT_SERVICE_NAME = "jenkins-agent"
 APT_PACKAGE_NAME = "jenkins-agent"
-APT_PACKAGE_VERSION = "1.0.4"
+APT_PACKAGE_VERSION = "1.0.5"
 SYSTEMD_SERVICE_CONF_DIR = "/etc/systemd/system/jenkins-agent.service.d/"
 PPA_URI = "https://ppa.launchpadcontent.net/canonical-is-devops/jenkins-agent-charm/ubuntu/"
 PPA_DEB_SRC = "deb-https://ppa.launchpadcontent.net/canonical-is-devops/jenkins-agent-charm/ubuntu/-"  # noqa: E501 pylint: disable=line-too-long


### PR DESCRIPTION
Bump package version to 1.0.5 which includes logic to clean up healthcheck file at `$JENKINS_HOME/.ready` to avoid reporting the wrong status

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
