### PR TITLE
remove package version pin due to PPA only keeping one version of the deb package

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -18,7 +18,6 @@ from charm_state import State
 logger = logging.getLogger(__name__)
 AGENT_SERVICE_NAME = "jenkins-agent"
 APT_PACKAGE_NAME = "jenkins-agent"
-APT_PACKAGE_VERSION = "1.0.6"
 SYSTEMD_SERVICE_CONF_DIR = "/etc/systemd/system/jenkins-agent.service.d/"
 PPA_URI = "https://ppa.launchpadcontent.net/canonical-is-devops/jenkins-agent-charm/ubuntu/"
 PPA_DEB_SRC = "deb-https://ppa.launchpadcontent.net/canonical-is-devops/jenkins-agent-charm/ubuntu/-"  # noqa: E501 pylint: disable=line-too-long
@@ -117,7 +116,7 @@ class JenkinsAgentService:
             # Install the necessary packages
             apt.update()
             apt.add_package("openjdk-17-jre")
-            apt.add_package(package_names=APT_PACKAGE_NAME, version=APT_PACKAGE_VERSION)
+            apt.add_package(package_names=APT_PACKAGE_NAME)
         except (apt.PackageError, apt.PackageNotFoundError, apt.GPGKeyError) as exc:
             raise PackageInstallError("Error installing the agent package") from exc
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -68,7 +68,6 @@ def test_on_install(harness: ops.testing.Harness, monkeypatch: pytest.MonkeyPatc
     assert apt_add_package_mock.call_count == 2
     assert apt_add_package_mock.call_args_list[0][0][0] == "openjdk-17-jre"
     assert apt_add_package_mock.call_args_list[1][1]["package_names"] == service.APT_PACKAGE_NAME
-    assert apt_add_package_mock.call_args_list[1][1]["version"] == service.APT_PACKAGE_VERSION
 
     assert harness.charm.unit.status.name == ops.BlockedStatus.name
 


### PR DESCRIPTION
The jenkins-agent package that the charm uses is uploaded to IS charm's PPA: https://launchpad.net/~canonical-is-devops/+archive/ubuntu/jenkins-agent-charm.

Due to how PPAs work only the latest version of the package is available via apt, this defeats the purpose of version pinning since there's always only one version at any given time. 

Since there's no future plan to move the package outside of the PPA, we should remove this pin.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
