### PR TITLE
Reset restart failed count on update status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -109,6 +109,11 @@ class JenkinsAgentCharm(ops.CharmBase):
             self.model.unit.status = ops.BlockedStatus("Waiting for relation.")
             return
 
+        # set NRestart of the service back to 0
+        # We do it here because at this point we can be certain that
+        # the service is up and running
+        self.jenkins_agent_service.reset_failed_state()
+
         self.model.unit.status = ops.ActiveStatus()
 
 

--- a/src/service.py
+++ b/src/service.py
@@ -166,6 +166,20 @@ class JenkinsAgentService:
         if not self._startup_check():
             raise ServiceRestartError("Error waiting for the agent service to start")
 
+    def reset_failed_state(self) -> None:
+        """Reset NRestart count of service back to 0.
+
+        The service keeps track of the 'restart-count' and blocks further restarts
+        if the maximum allowed is reached. This count is not reset when the service restarts
+        so we need to do it manually.
+        """
+        try:
+            # Disable protected-access here because reset-failed is not implemented in the lib
+            systemd._systemctl("reset-failed", AGENT_SERVICE_NAME)  # pylint: disable=W0212
+        except systemd.SystemdError:
+            # We only log the exception here as this is not critical
+            logger.error("Failed to reset failed state")
+
     def reset(self) -> None:
         """Stop the agent service and clear its configuration file.
 

--- a/src/service.py
+++ b/src/service.py
@@ -17,7 +17,7 @@ from charm_state import State
 
 logger = logging.getLogger(__name__)
 AGENT_SERVICE_NAME = "jenkins-agent"
-APT_PACKAGE_VERSION = "1.0.8"
+APT_PACKAGE_VERSION = "1.0.9"
 APT_PACKAGE_NAME = f"jenkins-agent-{APT_PACKAGE_VERSION}"
 SYSTEMD_SERVICE_CONF_DIR = "/etc/systemd/system/jenkins-agent.service.d/"
 PPA_URI = "https://ppa.launchpadcontent.net/canonical-is-devops/jenkins-agent-charm/ubuntu/"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, PropertyMock
 import ops
 import ops.testing
 import pytest
+from charms.operator_libs_linux.v1 import systemd
 
 import charm_state
 import service
@@ -173,6 +174,27 @@ def test_update_status_service_active(
     """
     harness.add_relation(charm_state.AGENT_RELATION, "jenkins-k8s")
     monkeypatch.setattr(service.JenkinsAgentService, "is_active", PropertyMock(return_value=True))
+    monkeypatch.setattr(systemd, "_systemctl", MagicMock(side_effect=systemd.SystemdError))
+
+    harness.begin()
+
+    harness.charm.on.update_status.emit()
+
+    assert harness.charm.unit.status.name == ops.ActiveStatus.name
+
+
+def test_update_status_reset_failed_state_systemd_error(
+    harness: ops.testing.Harness, monkeypatch: pytest.MonkeyPatch
+):
+    """
+    arrange: given a charm with relation to jenkins and the service is active.
+    act: when update-status hook is fired with reset-failed raising an error.
+    assert: The charm correctly ignore the error and sets the status to active.
+    """
+    harness.add_relation(charm_state.AGENT_RELATION, "jenkins-k8s")
+    monkeypatch.setattr(service.JenkinsAgentService, "is_active", PropertyMock(return_value=True))
+    monkeypatch.setattr(systemd, "_systemctl", MagicMock(side_effect=systemd.SystemdError))
+
     harness.begin()
 
     harness.charm.on.update_status.emit()


### PR DESCRIPTION
bump to v1.0.9 which includes better handling of systemd service restarts

Add a call to `systemctl reset-failed jenkins-agent.service` in update status hook if the service is active to ensure that the service is not blocked by NRestart reaching the maximum allowed.

## Rationale 
If NRestart reached the maximum configured, the service will be blocked from restarting again until the count is set back to 0. [By default the max count is 5](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=), [I've set it to 60 in the package](https://github.com/canonical/jenkins-agent-deb/blob/4922cb84c7e951948e83d994b72b80d798b47740/debian/jenkins-agent-1.0.9.jenkins-agent.service#L4) to give the service 5 mins to "self-heal"

The thing is the restart count is kept between restarts.

For example if the connection breaks and the service needed to restart 10 times to reconnect, this count is kept forever if we don't run systemctl reset-failed. So after 6 or so incidents like that the service will be blocked from restarting.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
