### PR TITLE
apt packages from config

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,4 +17,4 @@ jobs:
         ./tests/integration/pre_run_script.sh"
       juju-channel: 3.1/stable
       channel: 1.27-strict/stable
-      tmate-ssh-debug: true
+      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,4 +17,3 @@ jobs:
         ./tests/integration/pre_run_script.sh"
       juju-channel: 3.1/stable
       channel: 1.27-strict/stable
-      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,3 +17,4 @@ jobs:
         ./tests/integration/pre_run_script.sh"
       juju-channel: 3.1/stable
       channel: 1.27-strict/stable
+      tmate-ssh-debug: true

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,8 @@ options:
     description: |
       Comma-separated list of labels to be assigned to the agent in Jenkins. If not set it will
       default to the agents hardware identifier, e.g.: 'x86_64'
+  apt-packages:
+    type: string
+    default: ""
+    description: |
+      Comma-separated list of apt packages to install on the machine.

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,6 +59,13 @@ class JenkinsAgentCharm(ops.CharmBase):
 
     def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
         """Handle config changed event. Update the agent's label in the relation's databag."""
+        try:
+            self.jenkins_agent_service.install_apt_packages(self.state.apt_packages)
+        except service.PackageInstallError as exc:
+            logger.error("Error installing apt packages %s", exc)
+            self.unit.status = ops.BlockedStatus("Error installing apt packages: %s")
+            return
+
         if agent_relation := self.model.get_relation(AGENT_RELATION):
             relation_data = self.state.agent_meta.as_dict()
             agent_relation.data[self.unit].update(relation_data)

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,11 +59,13 @@ class JenkinsAgentCharm(ops.CharmBase):
 
     def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
         """Handle config changed event. Update the agent's label in the relation's databag."""
+        logger.info("CONFIG CHANGED")
+        logger.info("%s", self.state.apt_packages)
         try:
             self.jenkins_agent_service.install_apt_packages(self.state.apt_packages)
         except service.PackageInstallError as exc:
             logger.error("Error installing apt packages %s", exc)
-            self.unit.status = ops.BlockedStatus("Error installing apt packages: %s")
+            self.model.unit.status = ops.BlockedStatus("Error installing apt packages: %s")
             return
 
         if agent_relation := self.model.get_relation(AGENT_RELATION):

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,8 +59,6 @@ class JenkinsAgentCharm(ops.CharmBase):
 
     def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
         """Handle config changed event. Update the agent's label in the relation's databag."""
-        logger.info("CONFIG CHANGED")
-        logger.info("%s", self.state.apt_packages)
         try:
             self.jenkins_agent_service.install_apt_packages(self.state.apt_packages)
         except service.PackageInstallError as exc:

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -117,7 +117,7 @@ def _get_credentials_from_agent_relation(
     return Credentials(address=address, secret=secret)
 
 
-def _get_packages_to_install(charm: ops.CharmBase) -> tuple[str, ...]:
+def _get_packages_to_install(charm: ops.CharmBase) -> typing.Tuple[str, ...]:
     """Get list of apt packages to install from charm configuration.
 
     Args:
@@ -147,7 +147,7 @@ class State:
 
     agent_meta: AgentMeta
     agent_relation_credentials: typing.Optional[Credentials]
-    apt_packages: tuple[str, ...]
+    apt_packages: typing.Tuple[str, ...]
     unit_data: UnitData
     jenkins_agent_service_name: str = "jenkins-agent"
 

--- a/src/service.py
+++ b/src/service.py
@@ -8,6 +8,7 @@ import os
 import pwd
 import time
 from pathlib import Path
+from typing import Iterable
 
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import systemd
@@ -122,6 +123,21 @@ class JenkinsAgentService:
             apt.add_package(package_names=APT_PACKAGE_NAME)
         except (apt.PackageError, apt.PackageNotFoundError, apt.GPGKeyError) as exc:
             raise PackageInstallError("Error installing the agent package") from exc
+
+    @classmethod
+    def install_apt_packages(cls, packages: Iterable[str]):
+        """Install apt packages.
+
+        Args:
+            packages: The apt packages to install.
+        """
+        to_install = list(packages)
+        if not to_install:
+            return
+        try:
+            apt.add_package(to_install, update_cache=True)
+        except apt.PackageNotFoundError as exc:
+            raise PackageInstallError from exc
 
     def restart(self) -> None:
         """Start the agent service.

--- a/src/service.py
+++ b/src/service.py
@@ -125,18 +125,21 @@ class JenkinsAgentService:
             raise PackageInstallError("Error installing the agent package") from exc
 
     @classmethod
-    def install_apt_packages(cls, packages: Iterable[str]):
+    def install_apt_packages(cls, packages: Iterable[str]) -> None:
         """Install apt packages.
 
         Args:
             packages: The apt packages to install.
+
+        Raises:
+            PackageInstallError: If there was an error installing the package.
         """
         to_install = list(packages)
         if not to_install:
             return
         try:
             apt.add_package(to_install, update_cache=True)
-        except apt.PackageNotFoundError as exc:
+        except apt.Error as exc:
             raise PackageInstallError from exc
 
     def restart(self) -> None:

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -82,5 +82,5 @@ async def test_agent_packages(
 
     unit: Unit = jenkins_agent_application.units[0]
 
-    assert "/usr/bin/bzr" == await unit.ssh(["which", "bzr"])
-    assert "/usr/bin/ping" == await unit.ssh(["which", "ping"])
+    assert "/usr/bin/bzr" == await unit.ssh("which bzr")
+    assert "/usr/bin/ping" == await unit.ssh("which ping")

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -82,5 +82,5 @@ async def test_agent_packages(
 
     unit: Unit = jenkins_agent_application.units[0]
 
-    assert "/usr/bin/bzr" == await unit.ssh("which bzr")
-    assert "/usr/bin/ping" == await unit.ssh("which ping")
+    assert "/usr/bin/bzr\n" == await unit.ssh("which bzr")
+    assert "/usr/bin/ping\n" == await unit.ssh("which ping")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -89,7 +89,7 @@ def test_on_install_packages_fail(monkeypatch: pytest.MonkeyPatch):
     "packages",
     [
         pytest.param(tuple(), id="No packages"),
-        pytest.param(tuple("hello", "world"), id="Has packages"),
+        pytest.param(("hello", "world"), id="Has packages"),
     ],
 )
 def test_on_install_packages(monkeypatch: pytest.MonkeyPatch, packages: tuple[str, ...]):
@@ -103,7 +103,7 @@ def test_on_install_packages(monkeypatch: pytest.MonkeyPatch, packages: tuple[st
     JenkinsAgentService.install_apt_packages(packages)
 
     if packages:
-        apt_mock.assert_has_calls()
+        apt_mock.assert_called_once()
 
 
 def test_restart_service(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -6,6 +6,7 @@
 """Test for service interaction."""
 
 import os
+import typing
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -92,7 +93,7 @@ def test_on_install_packages_fail(monkeypatch: pytest.MonkeyPatch):
         pytest.param(("hello", "world"), id="Has packages"),
     ],
 )
-def test_on_install_packages(monkeypatch: pytest.MonkeyPatch, packages: tuple[str, ...]):
+def test_on_install_packages(monkeypatch: pytest.MonkeyPatch, packages: typing.Tuple[str, ...]):
     """
     arrange: Given a monkeypatched apt lib and list of packages to install.
     act: when install_apt_packages is called.

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -5,6 +5,9 @@
 
 """Test for charm state."""
 
+# Need access to protected functions for testing
+# pylint:disable=protected-access
+
 import os
 from unittest.mock import MagicMock
 
@@ -14,6 +17,7 @@ import pytest
 
 import charm_state
 from charm import JenkinsAgentCharm
+from charm_state import APT_PACKAGES_CONFIG
 
 
 def test_from_charm_invalid_metadata(
@@ -30,3 +34,25 @@ def test_from_charm_invalid_metadata(
 
     with pytest.raises(charm_state.InvalidStateError, match="Invalid executor state."):
         charm_state.State.from_charm(charm=charm)
+
+
+@pytest.mark.parametrize(
+    "packages, expected",
+    [
+        pytest.param("", tuple(), id="empty"),
+        pytest.param("git,bzr", ("git", "bzr"), id="has packages"),
+    ],
+)
+def test__get_packages_to_install(
+    harness: ops.testing.Harness, packages: str, expected: tuple[str, ...]
+):
+    """
+    arrange: given charm apt-packages config.
+    act: when _get_packages_to_install is called.
+    assert: packages are correctly parsed.
+    """
+    harness.begin()
+    harness.update_config({APT_PACKAGES_CONFIG: packages})
+    charm: JenkinsAgentCharm = harness.charm
+
+    assert charm_state._get_packages_to_install(charm=charm) == expected

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -9,6 +9,7 @@
 # pylint:disable=protected-access
 
 import os
+import typing
 from unittest.mock import MagicMock
 
 import ops
@@ -44,7 +45,7 @@ def test_from_charm_invalid_metadata(
     ],
 )
 def test__get_packages_to_install(
-    harness: ops.testing.Harness, packages: str, expected: tuple[str, ...]
+    harness: ops.testing.Harness, packages: str, expected: typing.Tuple[str, ...]
 ):
     """
     arrange: given charm apt-packages config.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Allow installing apt packages through configuration.

### Rationale

To automate setup of agents.

### Juju Events Changes

- on config changed: install apt packages from charm config.

### Module Changes

- service: Added method to install apt packages.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
