### PR TITLE
Update docs

### DIFF
--- a/docs/explanation/workload.md
+++ b/docs/explanation/workload.md
@@ -1,5 +1,5 @@
 # Managing workload inside the charm
-The core jenkins agent workload requires 3 main parameters (JENKINS_URL, JENKINS_AGENT and JENKINS_SECRET) and is defined as a 2-step process:
+The core Jenkins agent workload requires 3 main parameters (JENKINS_URL, JENKINS_AGENT and JENKINS_SECRET) and is defined as a 2-step process:
 
 1. Download the agent binary at JENKINS_URL/jnlpJars/agent.jar and store it in the agent’s home directory
 2. Run the agent binary with the following parameters to register the node with Jenkins

--- a/docs/how-to/configure-agent-node-label.md
+++ b/docs/how-to/configure-agent-node-label.md
@@ -3,7 +3,7 @@
 ### Configure `jenkins_agent_labels`
 
 Use the `jenkins_agent_labels` configuration to allow assigning different labels to the agent's node on the jenkins server.
-Comma-separated list of node labels. If empty, the agent's node will have the underlying machine's arch as a label by default, most of the time this will be `x86_64`. If this value is configured before any integrations with the jenkins charm is established, the label will be applied during the node's creation once an integration has been established.
+The configuration is a comma-separated list of node labels. If empty, the agent's node will have the underlying machine's architecture as a label by default, for instance `x86_64`. If this value is configured before any integrations with the Jenkins charm are established, the label will be applied during the node's creation once an integration has been established.
 
 ```
 juju config jenkins-agent jenkins_agent_labels=label1,label2,label3

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -16,10 +16,10 @@ bootstrapping different clouds [here](https://juju.is/docs/olm/get-started-with-
 Use `juju bootstrap localhost localhost` to bootstrap a `lxd` machine controller with the name
 `localhost` for tutorial purposes.
 
-### Setting up the tutorial model
+### Set up the tutorial model
 
-To easily clean up the resources and to separate your workload from the contents of this tutorial,
-it is recommended to set up a new model with the following command.
+To easily clean up the resources and to separate your workload from the contents of this tutorial, 
+set up a new model with the following command.
 
 ```
 juju add-model tutorial
@@ -46,7 +46,7 @@ Use `juju bootstrap microk8s localhost-microk8s` to bootstrap a `microk8s` machi
 
 Then, switch to your kubernetes controller add a model for the jenkins-k8s charm with the following command:
 ```
-juju switch -c localhost-microk8s
+juju switch localhost-microk8s
 juju add-model jenkins-tutorial
 ```
 
@@ -55,14 +55,16 @@ Continue by deploying the jenkins-k8s charm. by default it will deploy the lates
 juju deploy jenkins-k8s --channel=latest/edge
 ```
 
-The Jenkins application can only have a single server unit. Adding more units through --num-units parameter will cause the application to misbehave.
+> NOTE: The Jenkins application can only have a single server unit. Adding more units through the `--num-units` parameter will cause the application to misbehave.
 
 #### Create an offer for Cross Model Integration
 
 To integrate charms
-[across different models](https://juju.is/docs/juju/manage-cross-model-integrations), a juju
-[`offer`](https://juju.is/docs/juju/manage-cross-model-integrations#heading--create-an-offer) is
+[across different models](https://juju.is/docs/juju/manage-cross-model-integrations), a Juju
+[`offer`](https://juju.is/docs/juju/juju-offer) is
 required.
+
+> See more: [Create an offer](https://juju.is/docs/juju/manage-cross-model-integrations#heading--create-an-offer)
 
 Create an offer of the `jenkins-k8s` charm's `agent` integration.
 
@@ -78,8 +80,11 @@ Application "jenkins-k8s" endpoints [agent] available at "admin/jenkins-tutorial
 
 #### Integrate the Jenkins agent charm through the offer
 
-Switch back to the k8s model where the `jenkins-agent` charm is deployed. An example of the switch
-command looks like the following: `juju switch localhost:tutorial`.
+Switch back to the k8s model where the `jenkins-agent` charm is deployed: 
+
+```
+juju switch localhost:tutorial
+```
 
 Integrate the `jenkins-agent` charm to the `jenkins-k8s` server charm through the offer.
 The syntax of the offer is as follows: `<controller>:<user>/<model>.<charm>`.
@@ -89,12 +94,12 @@ juju integrate jenkins-agent:agent localhost-microk8s:admin/jenkins-tutorial.jen
 ```
 
 
-### Cleaning up the environment
+### Clean up the environment
 
 Congratulations! You have successfully finished the tutorial. You can now remove the
 models that you’ve created using the following command.
 
 ```
-juju destroy model localhost-microk8s:admin/jenkins-tutorial -y --release-storage
-juju destroy model localhost:admin/tutorial -y --release-storage
+juju destroy-model localhost-microk8s:admin/jenkins-tutorial --destroy-storage
+juju destroy-model localhost:admin/tutorial --destroy-storage
 ```


### PR DESCRIPTION
### Overview

Small changes to the documentation that are specific to the jenkins-agent-operator charm.

### Rationale

- Tutorial: Fixed outdated commands, updated headings to have consistent grammar, formatted two items as notes
- How-to guide: Fixed a fragmented sentence, capitalised Jenkins where appropriate, "arch" --> "architecture", removed the assumption about x86_64 arch and turned it into an example
- Explanation: Capitalised Jenkins where appropriate 

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
