### PR TITLE
chore: drop support for focal (LTS out of support)

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,5 +17,3 @@ jobs:
         ./tests/integration/pre_run_script.sh"
       juju-channel: 3.5/stable
       channel: 1.29-strict/stable
-      tmate-debug: true
-      tmate-timeout: 120

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,3 +17,5 @@ jobs:
         ./tests/integration/pre_run_script.sh"
       juju-channel: 3.5/stable
       channel: 1.29-strict/stable
+      tmate-debug: true
+      tmate-timeout: 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ops==2.21.1
-requests==2.32.3
-pydantic==1.10.21
+ops==2.22.0
+requests==2.32.4
+pydantic==1.10.22
 jinja2==3.1.6
 python-dotenv==1.1.0

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -65,7 +65,7 @@ class UnitData(BaseModel):
         series: The base of the machine on which the charm is running.
     """
 
-    series: Literal["focal", "jammy", "noble"]
+    series: Literal["jammy", "noble"]
 
 
 class InvalidStateError(Exception):
@@ -166,7 +166,7 @@ class State:
 
         # Load series information
         os_release: dict = dotenv_values("/etc/os-release")
-        unit_series = os_release.get("UBUNTU_CODENAME")
+        unit_series = os_release.get("UBUNTU_CODENAME", "")
         try:
             unit_data = UnitData(series=unit_series)
         except ValidationError as exc:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,9 +43,7 @@ def model_fixture(ops_test: OpsTest) -> Model:
     return ops_test.model
 
 
-@pytest_asyncio.fixture(
-    scope="function", name="jenkins_agent_application", params=["focal", "jammy"]
-)
+@pytest_asyncio.fixture(scope="function", name="jenkins_agent_application", params=["jammy"])
 async def application_fixture(
     model: Model, charm: str, request: typing.Any
 ) -> typing.AsyncGenerator[Application, None]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,9 @@ def model_fixture(ops_test: OpsTest) -> Model:
     return ops_test.model
 
 
-@pytest_asyncio.fixture(scope="function", name="jenkins_agent_application", params=["jammy"])
+@pytest_asyncio.fixture(
+    scope="function", name="jenkins_agent_application", params=["jammy", "noble"]
+)
 async def application_fixture(
     model: Model, charm: str, request: typing.Any
 ) -> typing.AsyncGenerator[Application, None]:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Drops support for focal bases (out of LTS support)

<!-- A high level overview of the change -->

### Rationale

- The latest ops library is no longer compatible with Python 3.8 due to typing extensions _SpecialGenericAlias no longer being available, which is used by the tracing lib inside ops lib.
- This unblocks all the failing CIs #67 #70 #72
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
