### PR TITLE
Re-check Vale and fix errors

### DIFF
--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,3 +1,3 @@
-# Deploy the jenkins-agent-operator charm for the first time
+# Deploy the Jenkins agent charm for the first time
 
 See the [full Jenkins tutorial](https://charmhub.io/jenkins-k8s/docs/tutorial-getting-started) in the jenkins-k8s-operator documentation.


### PR DESCRIPTION
Applicable ticket: ISD-3949

### Overview

Run Vale checks locally and fix errors.

### Rationale

There's a bug in operator-workflows that points to an older version of the Canonical Vale style checks. Therefore some of the checks will be missed in the GitHub CI.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`trivial`, `senior-review-required`)

<!-- Explanation for any unchecked items above -->
Either discourse-gatekeeper will update the documentation on Charmhub or I'll do it after the approval of this PR.
