### PR TITLE
ci: fix naming for required status checks

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -44,7 +44,7 @@ jobs:
       - integration-tests-non-amd64
     uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
 
-  integration-tests:
+  integration tests:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Remove integration status dash in name to follow repo-automation settings https://github.com/canonical/canonical-repo-automation/blob/main/groups/is/platform-engineering/repos/jenkins-agent-operator/inputs.hcl#L9
<!-- A high level overview of the change -->

### Rationale

- Fix required check

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`trivial`, `senior-review-required`)

<!-- Explanation for any unchecked items above -->
