### PR TITLE
fix: recover agent on server URL change and improve systemd restart limits

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   unit-tests:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ stage/
 .vale/styles/config/vocabularies/*
 !.vale/styles/config/vocabularies/local
 # END VALE WORKFLOW IGNORE
+.DS_Store

--- a/src/agent_observer.py
+++ b/src/agent_observer.py
@@ -63,17 +63,21 @@ class Observer(ops.Object):
         Raises:
             RuntimeError: when the service fails to properly start.
         """
-        # Check if the jenkins agent service has started and set agent ready.
-        # This is to prevent relation data from other units to trigger a service restart.
-        if self.jenkins_agent_service.is_active:
-            logger.warning("Given agent already registered. Skipping.")
-            return
-
         # If relation data is not yet available to this unit, set its status to waiting
         if not self.state.agent_relation_credentials:
             self.charm.unit.status = ops.WaitingStatus("Waiting for complete relation data.")
             logger.info("Waiting for complete relation data.")
             return
+
+        # If the service is already active, check whether the server URL has changed.
+        # A Jenkins server pod restart assigns a new IP, requiring agents to reconnect.
+        if self.jenkins_agent_service.is_active:
+            if not self.jenkins_agent_service.credentials_changed(
+                self.state.agent_relation_credentials
+            ):
+                logger.info("Agent service running with current credentials. No restart needed.")
+                return
+            logger.info("Server credentials changed. Restarting agent service.")
 
         # Try to start the service with the obtained credentials from relation data
         self.charm.unit.status = ops.MaintenanceStatus("Starting jenkins agent service")

--- a/src/charm.py
+++ b/src/charm.py
@@ -97,14 +97,15 @@ class JenkinsAgentCharm(ops.CharmBase):
         """Update status event hook.
 
         Raises:
-            RuntimeError: when the service is not running.
+            RuntimeError: when the service cannot be recovered.
         """
-        if self.model.get_relation(AGENT_RELATION) and not self.jenkins_agent_service.is_active:
-            logger.error("agent related to Jenkins but service is not active")
-            raise RuntimeError("jenkins-agent service is not running")
-
         if not self.model.get_relation(AGENT_RELATION):
             self.model.unit.status = ops.BlockedStatus("Waiting for relation.")
+            return
+
+        if not self.jenkins_agent_service.is_active:
+            logger.warning("Agent related to Jenkins but service is not active. Recovering.")
+            self.restart_agent_service()
             return
 
         # set NRestart of the service back to 0

--- a/src/service.py
+++ b/src/service.py
@@ -6,14 +6,16 @@
 import logging
 import os
 import pwd
+import re
 import time
+import typing
 from pathlib import Path
 
 import jinja2
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import systemd
 
-from charm_state import State
+from charm_state import Credentials, State
 
 logger = logging.getLogger(__name__)
 AGENT_SERVICE_NAME = "jenkins-agent"
@@ -25,6 +27,26 @@ JENKINS_HOME = Path("/var/lib/jenkins")
 JENKINS_AGENT_SYSTEMD_PATH = Path("/etc/systemd/system/jenkins-agent.service")
 JENKINS_AGENT_START_SCRIPT_PATH = Path("/usr/bin/jenkins-agent")
 AGENT_READY_PATH = Path(JENKINS_HOME / ".ready")
+
+# Pattern for systemd Environment="KEY=VALUE" lines.
+_SYSTEMD_ENV_PATTERN = re.compile(r'^Environment="([^=]+)=(.*)"$')
+
+
+def _parse_systemd_env(content: str) -> typing.Dict[str, str]:
+    """Parse Environment directives from a systemd override.conf file.
+
+    Args:
+        content: The file content to parse.
+
+    Returns:
+        A dictionary of environment variable key-value pairs.
+    """
+    env: typing.Dict[str, str] = {}
+    for line in content.splitlines():
+        match = _SYSTEMD_ENV_PATTERN.match(line.strip())
+        if match:
+            env[match.group(1)] = match.group(2)
+    return env
 
 
 class PackageInstallError(Exception):
@@ -95,6 +117,24 @@ class JenkinsAgentService:
         except SystemError as exc:
             logger.error("Failed to call systemctl:\n%s", exc)
             return False
+
+    def credentials_changed(self, credentials: Credentials) -> bool:
+        """Check whether the current service credentials differ from the given ones.
+
+        Args:
+            credentials: The credentials to compare against the running configuration.
+
+        Returns:
+            True if the credentials have changed, False otherwise.
+        """
+        config_file = Path(f"{SYSTEMD_SERVICE_CONF_DIR}/override.conf")
+        if not config_file.exists():
+            return True
+        current_env = _parse_systemd_env(config_file.read_text())
+        return (
+            current_env.get("JENKINS_URL") != credentials.address
+            or current_env.get("JENKINS_TOKEN") != credentials.secret
+        )
 
     def install(self) -> None:
         """Install and set up the jenkins agent apt package.

--- a/templates/jenkins_agent.service
+++ b/templates/jenkins_agent.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Jenkins inbound agent
-StartLimitIntervalSec=infinity
-StartLimitBurst=60
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
-Restart=always
+Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/jenkins-agent
 ExecStopPost=rm -rf /var/lib/jenkins/.ready

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -5,12 +5,15 @@
 
 import logging
 import textwrap
+import time
 
 import jenkinsapi.jenkins
 import jubilant
 import pytest
 
 logger = logging.getLogger()
+
+JENKINS_APPLICATION_NAME = "jenkins-k8s"
 
 
 def _gen_test_job_xml(node_label: str):
@@ -93,3 +96,87 @@ def test_agent_relation(jenkins_client: jenkinsapi.jenkins.Jenkins, active_agent
         agent_name=agent_name,
         test_target_label="machine",
     )
+
+
+def _wait_for_agent_online(
+    jenkins_client: jenkinsapi.jenkins.Jenkins, agent_name: str, timeout: int = 600
+) -> bool:
+    """Wait for a Jenkins agent to come online.
+
+    Args:
+        jenkins_client: The Jenkins API client.
+        agent_name: The agent node name.
+        timeout: Maximum wait time in seconds.
+
+    Returns:
+        True if the agent came online within the timeout.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            node = jenkins_client.get_node(agent_name)
+            if node.is_online():
+                return True
+        except Exception:  # nosec B110
+            pass
+        time.sleep(10)
+    return False
+
+
+def test_agent_reconnects_after_server_refresh(
+    jenkins_client: jenkinsapi.jenkins.Jenkins,
+    active_agent: str,
+    juju: jubilant.Juju,
+    microk8s_juju: jubilant.Juju,
+    use_docker: bool,
+):
+    """
+    arrange: given a Jenkins server and registered agent that is active and online.
+    act: when the Jenkins server charm is refreshed (simulating pod restart / URL change).
+    assert: the agent reconnects and comes back online without manual intervention.
+    """
+    if use_docker:
+        pytest.skip("Server refresh test requires Juju-deployed Jenkins server")
+
+    agent_name = f"{active_agent}-0"
+
+    # Verify agent is initially online.
+    node = jenkins_client.get_node(agent_name)
+    assert node.is_online(), f"Agent {agent_name} should be online before refresh"
+
+    # Refresh the Jenkins server charm to trigger pod restart and IP change.
+    logger.info("Refreshing Jenkins server charm to trigger pod restart...")
+    microk8s_juju.cli("refresh", JENKINS_APPLICATION_NAME, "--channel", "latest/edge")
+    microk8s_juju.wait(jubilant.all_agents_idle, timeout=60 * 15)
+    microk8s_juju.wait(jubilant.all_active, timeout=60 * 15)
+
+    # The server may have a new IP. Re-create the client with the new address.
+    unit_status = (
+        microk8s_juju.status()
+        .get_units(JENKINS_APPLICATION_NAME)
+        .get(f"{JENKINS_APPLICATION_NAME}/0")
+    )
+    assert unit_status, "Jenkins server unit not found after refresh"
+    new_address = unit_status.address
+    logger.info("Jenkins server new address after refresh: %s", new_address)
+
+    result = microk8s_juju.run(f"{JENKINS_APPLICATION_NAME}/0", "get-admin-password")
+    password = result.results.get("password", "")
+    assert password, "Failed to get admin password after refresh"
+
+    new_client = jenkinsapi.jenkins.Jenkins(
+        baseurl=f"http://{new_address}:8080",
+        username="admin",
+        password=password,
+        timeout=60,
+    )
+
+    # Wait for agent to reconnect (the charm should detect the URL change and restart).
+    juju.wait(jubilant.all_agents_idle, timeout=60 * 5)
+    assert _wait_for_agent_online(new_client, agent_name, timeout=600), (
+        f"Agent {agent_name} did not reconnect after server refresh within 10 minutes"
+    )
+
+    # Verify agent is functional by checking it's online.
+    node = new_client.get_node(agent_name)
+    assert node.is_online(), f"Agent {agent_name} should be online after reconnection"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@
 """Fixtures for jenkins-agent charm tests."""
 
 import secrets
+from unittest.mock import patch
 
 import pytest
 from ops.testing import Harness
@@ -24,6 +25,16 @@ def service_configuration_template_fixture(agent_relation_data: dict) -> str:
 Environment="JENKINS_TOKEN={agent_relation_data.get("jenkins-agent-0_secret")}"
 Environment="JENKINS_URL={agent_relation_data.get("url")}"
 Environment="JENKINS_AGENT=jenkins-agent-0"'''
+
+
+@pytest.fixture(autouse=True)
+def mock_os_release():
+    """Mock /etc/os-release so State.from_charm works on any platform."""
+    with patch(
+        "charm_state.dotenv_values",
+        return_value={"UBUNTU_CODENAME": "noble"},
+    ):
+        yield
 
 
 @pytest.fixture(scope="function", name="harness")

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -91,26 +91,40 @@ def test_agent_relation_changed_service_restart_error(
         harness.charm.on.agent_relation_changed.emit(harness.model.get_relation(AGENT_RELATION))
 
 
+@pytest.mark.parametrize(
+    "creds_changed,expect_restart",
+    [
+        pytest.param(False, 0, id="no_change"),
+        pytest.param(True, 1, id="credentials_changed"),
+    ],
+)
 def test_agent_relation_changed_service_already_active(
     harness_with_agent_relation: ops.testing.Harness,
     monkeypatch: pytest.MonkeyPatch,
+    creds_changed: bool,
+    expect_restart: int,
 ):
     """
     arrange: initialized jenkins-agent charm related to jenkins-k8s charm with relation data.
-    act: Trigger _on_agent_relation_changed hook when the service is already up.
-    assert: The charm skips restarting the agent service.
+    act: Trigger _on_agent_relation_changed hook when the service is already active.
+    assert: The charm restarts only when credentials have changed.
     """
     service_restart_mock = MagicMock()
     service_is_active_mock = PropertyMock(return_value=True)
+    credentials_changed_mock = MagicMock(return_value=creds_changed)
     monkeypatch.setattr(service.JenkinsAgentService, "restart", service_restart_mock)
     monkeypatch.setattr(service.JenkinsAgentService, "is_active", service_is_active_mock)
+    monkeypatch.setattr(
+        service.JenkinsAgentService, "credentials_changed", credentials_changed_mock
+    )
     harness = harness_with_agent_relation
     harness.begin()
 
     harness.charm.on.agent_relation_changed.emit(harness.model.get_relation(AGENT_RELATION))
 
     assert service_is_active_mock.call_count == 1
-    assert service_restart_mock.call_count == 0
+    assert credentials_changed_mock.call_count == 1
+    assert service_restart_mock.call_count == expect_restart
 
 
 def test_agent_relation_departed_service_stop_error(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -141,14 +141,17 @@ def test_update_status_service_not_active(
     """
     arrange: given a charm with relation to jenkins and the service is not active.
     act: when update-status hook is fired.
-    assert: The charm correctly raise a runtime error.
+    assert: The charm attempts recovery by restarting the agent service.
     """
     harness.add_relation(charm_state.AGENT_RELATION, "jenkins-k8s")
     monkeypatch.setattr(service.JenkinsAgentService, "is_active", PropertyMock(return_value=False))
     harness.begin()
 
-    with pytest.raises(RuntimeError, match=r"jenkins-agent service is not running"):
-        harness.charm.on.update_status.emit()
+    charm: JenkinsAgentCharm = harness.charm
+    monkeypatch.setattr(charm.state, "agent_relation_credentials", None)
+    charm.on.update_status.emit()
+
+    assert charm.unit.status.name == ops.WaitingStatus.name
 
 
 def test_update_status_service_waiting_for_relation(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -5,6 +5,8 @@
 
 """Test for service interaction."""
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -169,3 +171,83 @@ def test_service_is_active_systemd_error(
     charm: JenkinsAgentCharm = harness.charm
 
     assert not charm.jenkins_agent_service.is_active
+
+
+def test_parse_systemd_env():
+    """
+    arrange: A systemd override.conf with Environment directives.
+    act: Parse the content.
+    assert: The correct key-value pairs are extracted.
+    """
+    content = (
+        "[Service]\n"
+        'Environment="JENKINS_TOKEN=abc123"\n'
+        'Environment="JENKINS_URL=http://10.1.69.130:8080"\n'
+        'Environment="JENKINS_AGENT=jenkins-agent-k8s-0"'
+    )
+    result = service._parse_systemd_env(content)
+    assert result == {
+        "JENKINS_TOKEN": "abc123",
+        "JENKINS_URL": "http://10.1.69.130:8080",
+        "JENKINS_AGENT": "jenkins-agent-k8s-0",
+    }
+
+
+@pytest.mark.parametrize(
+    "override_content,cred_url,cred_secret,expected",
+    [
+        pytest.param(None, "http://new", "s", True, id="no_override_file"),
+        pytest.param(
+            "[Service]\n"
+            'Environment="JENKINS_TOKEN=secret123"\n'
+            'Environment="JENKINS_URL=http://10.1.69.130:8080"\n'
+            'Environment="JENKINS_AGENT=jenkins-agent-0"',
+            "http://10.1.69.130:8080",
+            "secret123",
+            False,
+            id="same_credentials",
+        ),
+        pytest.param(
+            "[Service]\n"
+            'Environment="JENKINS_TOKEN=secret123"\n'
+            'Environment="JENKINS_URL=http://10.1.69.130:8080"\n'
+            'Environment="JENKINS_AGENT=jenkins-agent-0"',
+            "http://10.1.69.153:8080",
+            "secret123",
+            True,
+            id="url_differs",
+        ),
+    ],
+)
+def test_credentials_changed(
+    harness: ops.testing.Harness,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    override_content: str | None,
+    cred_url: str,
+    cred_secret: str,
+    expected: bool,
+):
+    """
+    arrange: A service with or without an override.conf file.
+    act: Check if credentials changed against given values.
+    assert: Returns expected bool depending on file state and content.
+    """
+    config_dir = tmp_path / "override"
+    if override_content is not None:
+        config_dir.mkdir()
+        (config_dir / "override.conf").write_text(override_content)
+    monkeypatch.setattr(service, "SYSTEMD_SERVICE_CONF_DIR", str(config_dir))
+    harness.add_relation(
+        AGENT_RELATION,
+        "jenkins-k8s",
+        unit_data={"url": cred_url, "jenkins-agent-0_secret": cred_secret},
+    )
+    harness.begin()
+    charm: JenkinsAgentCharm = harness.charm
+    from charm_state import Credentials
+
+    result = charm.jenkins_agent_service.credentials_changed(
+        Credentials(address=cred_url, secret=cred_secret)
+    )
+    assert result is expected


### PR DESCRIPTION
## Summary

Fixes #92.

When a Jenkins server restarts or upgrades with a new IP, agents fail to reconnect because:
1. `StartLimitIntervalSec=infinity` permanently locks out the service after burst is reached
2. `_on_agent_relation_changed` skips restart when service is active, missing URL changes
3. `_on_update_status` raises RuntimeError instead of attempting recovery

## Changes

- **systemd service**: `StartLimitIntervalSec=300`, `StartLimitBurst=5`, `Restart=on-failure` (burst resets every 5 min)
- **agent_observer**: Compare current credentials against running config; restart only when URL/token changed
- **charm.py**: `update-status` attempts recovery instead of raising RuntimeError
- **service.py**: Add `credentials_changed()` method to detect stale JENKINS_URL/TOKEN in systemd override.conf
- **conftest**: Mock `/etc/os-release` so unit tests pass cross-platform

## Testing

All 29 unit tests pass. Manually verified on microk8s: deployed jenkins-k8s rev 285 + 3 agents, refreshed to rev 318, confirmed agents reconnect automatically.