### PR TITLE
fix(naming): agent name collision

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,3 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
+
+## 2026-06-15
+
+- Fix issue with agent applications with same name under different models.

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -148,7 +148,7 @@ class State:
             agent_meta = AgentMeta(
                 executors=tools.parse_obj_as(int, os.cpu_count()),
                 labels=charm.model.config.get("jenkins_agent_labels", "") or os.uname().machine,
-                name=charm.unit.name.replace("/", "-"),
+                name=f"{charm.model.name}-{charm.unit.name.replace('/', '-')}",
             )
         except ValidationError as exc:
             logging.error("Invalid executor state, %s", exc)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -298,7 +298,8 @@ def jenkins_agent_requirer_fixture(
         return JENKINS_APPLICATION_NAME
 
     # Register agent node for AnyCharm
-    model_name = juju.model.split(":")[-1] if ":" in juju.model else juju.model
+    assert juju.model, "model name required for agent node registration"
+    model_name: str = juju.model.split(":")[-1] if ":" in juju.model else juju.model
     agent_secret = _register_agent_node(jenkins_client=jenkins_client, model_name=model_name)
     juju.deploy(
         ANY_CHARM_APPLICATION_NAME,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -221,11 +221,12 @@ def jenkins_agent_application_fixture(
     return JENKINS_AGENT_APPLICATION_NAME
 
 
-def _register_agent_node(jenkins_client: jenkinsapi.jenkins.Jenkins):
+def _register_agent_node(jenkins_client: jenkinsapi.jenkins.Jenkins, model_name: str):
     """Register agent node.
 
     Args:
         jenkins_client: Jenkins server client.
+        model_name: Juju model name (used for model-prefixed agent name).
     """
     agent_node_meta = {
         "num_executors": 1,
@@ -234,7 +235,7 @@ def _register_agent_node(jenkins_client: jenkinsapi.jenkins.Jenkins):
         "labels": "machine",
         "exclusive": True,
     }
-    node_name = f"{JENKINS_AGENT_APPLICATION_NAME}-0"
+    node_name = f"{model_name}-{JENKINS_AGENT_APPLICATION_NAME}-0"
     jenkins_client.nodes.create_node(node_name, agent_node_meta)
     script = (
         f'println(jenkins.model.Jenkins.getInstance().getComputer("{node_name}").getJnlpMac())'
@@ -243,8 +244,16 @@ def _register_agent_node(jenkins_client: jenkinsapi.jenkins.Jenkins):
     return secret
 
 
-def _generate_any_charm_src_overwrite(jenkins_server_url: str, agent_node_secret: str):
-    """Generate any charm src."""
+def _generate_any_charm_src_overwrite(
+    jenkins_server_url: str, agent_node_secret: str, model_name: str
+):
+    """Generate any charm src.
+
+    Args:
+        jenkins_server_url: URL of the Jenkins server.
+        agent_node_secret: Secret token for the agent node.
+        model_name: Juju model name (used for context, agent name comes from relation data).
+    """
     return {
         "any_charm.py": textwrap.dedent(
             f"""\
@@ -267,9 +276,11 @@ def _generate_any_charm_src_overwrite(jenkins_server_url: str, agent_node_secret
                     return
                 relation.data[self.model.unit].update({{"url": "{jenkins_server_url}"}})
                 for unit in relation.units:
-                    relation.data[self.model.unit].update(
-                        {{f"{{unit.name.replace('/', '-')}}_secret": "{agent_node_secret}"}}
-                    )
+                    agent_name = relation.data[unit].get("name")
+                    if agent_name:
+                        relation.data[self.model.unit].update(
+                            {{f"{{agent_name}}_secret": "{agent_node_secret}"}}
+                        )
         """
         ),
     }
@@ -287,7 +298,8 @@ def jenkins_agent_requirer_fixture(
         return JENKINS_APPLICATION_NAME
 
     # Register agent node for AnyCharm
-    agent_secret = _register_agent_node(jenkins_client=jenkins_client)
+    model_name = juju.model.split(":")[-1] if ":" in juju.model else juju.model
+    agent_secret = _register_agent_node(jenkins_client=jenkins_client, model_name=model_name)
     juju.deploy(
         ANY_CHARM_APPLICATION_NAME,
         channel="latest/beta",
@@ -296,6 +308,7 @@ def jenkins_agent_requirer_fixture(
                 _generate_any_charm_src_overwrite(
                     jenkins_server_url=jenkins_client.base_server_url(),
                     agent_node_secret=agent_secret,
+                    model_name=model_name,
                 )
             )
         },

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -86,10 +86,11 @@ def test_agent_relation(jenkins_client: jenkinsapi.jenkins.Jenkins, active_agent
     act: when a job is created.
     assert: the agent is able to run job to completion.
     """
-    agent_name = f"{active_agent}-0"
     nodes = jenkins_client.get_nodes()
     assert all(node.is_online() for node in nodes.values())
-    assert any(node.name == agent_name for node in nodes.values())
+    agent_nodes = [node for node in nodes.values() if active_agent in node.name]
+    assert len(agent_nodes) == 1, f"Expected one agent node, found {len(agent_nodes)}"
+    agent_name = agent_nodes[0].name
 
     assert_job_success(
         client=jenkins_client,
@@ -138,7 +139,10 @@ def test_agent_reconnects_after_server_refresh(
     if use_docker:
         pytest.skip("Server refresh test requires Juju-deployed Jenkins server")
 
-    agent_name = f"{active_agent}-0"
+    nodes = jenkins_client.get_nodes()
+    agent_nodes = [node for node in nodes.values() if active_agent in node.name]
+    assert len(agent_nodes) == 1, f"Expected one agent node, found {len(agent_nodes)}"
+    agent_name = agent_nodes[0].name
 
     # Verify agent is initially online.
     node = jenkins_client.get_node(agent_name)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,16 +15,16 @@ from charm_state import AGENT_RELATION
 @pytest.fixture(scope="module", name="agent_relation_data")
 def agent_relation_data_fixture() -> dict:
     """Mock relation data for agent relation."""
-    return {"url": "http://example.com", "jenkins-agent-0_secret": secrets.token_hex(4)}
+    return {"url": "http://example.com", "test-model-jenkins-agent-0_secret": secrets.token_hex(4)}
 
 
 @pytest.fixture(scope="module", name="service_configuration_template")
 def service_configuration_template_fixture(agent_relation_data: dict) -> str:
     """Mock service environment variables configuration for jenkins-agent."""
     return f'''[Service]
-Environment="JENKINS_TOKEN={agent_relation_data.get("jenkins-agent-0_secret")}"
+Environment="JENKINS_TOKEN={agent_relation_data.get("test-model-jenkins-agent-0_secret")}"
 Environment="JENKINS_URL={agent_relation_data.get("url")}"
-Environment="JENKINS_AGENT=jenkins-agent-0"'''
+Environment="JENKINS_AGENT=test-model-jenkins-agent-0"'''
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +41,7 @@ def mock_os_release():
 def harness_fixture():
     """Enable ops test framework harness."""
     harness = Harness(JenkinsAgentCharm)
+    harness.set_model_name("test-model")
 
     yield harness
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -57,7 +57,7 @@ def test_agent_relation_changed_service_restart(
     assert charm.state.agent_relation_credentials
     assert (
         charm.state.agent_relation_credentials.secret
-        == agent_relation_data["jenkins-agent-0_secret"]
+        == agent_relation_data["test-model-jenkins-agent-0_secret"]
     )
     assert charm.state.agent_relation_credentials.address == agent_relation_data["url"]
     assert charm.unit.status.name == ops.ActiveStatus.name
@@ -80,7 +80,7 @@ def test_agent_relation_changed_service_restart_error(
     assert charm.state.agent_relation_credentials
     assert (
         charm.state.agent_relation_credentials.secret
-        == agent_relation_data["jenkins-agent-0_secret"]
+        == agent_relation_data["test-model-jenkins-agent-0_secret"]
     )
     assert charm.state.agent_relation_credentials.address == agent_relation_data["url"]
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -201,7 +201,7 @@ def test_parse_systemd_env():
             "[Service]\n"
             'Environment="JENKINS_TOKEN=secret123"\n'
             'Environment="JENKINS_URL=http://10.1.69.130:8080"\n'
-            'Environment="JENKINS_AGENT=jenkins-agent-0"',
+            'Environment="JENKINS_AGENT=test-model-jenkins-agent-0"',
             "http://10.1.69.130:8080",
             "secret123",
             False,
@@ -211,7 +211,7 @@ def test_parse_systemd_env():
             "[Service]\n"
             'Environment="JENKINS_TOKEN=secret123"\n'
             'Environment="JENKINS_URL=http://10.1.69.130:8080"\n'
-            'Environment="JENKINS_AGENT=jenkins-agent-0"',
+            'Environment="JENKINS_AGENT=test-model-jenkins-agent-0"',
             "http://10.1.69.153:8080",
             "secret123",
             True,
@@ -241,7 +241,7 @@ def test_credentials_changed(
     harness.add_relation(
         AGENT_RELATION,
         "jenkins-k8s",
-        unit_data={"url": cred_url, "jenkins-agent-0_secret": cred_secret},
+        unit_data={"url": cred_url, "test-model-jenkins-agent-0_secret": cred_secret},
     )
     harness.begin()
     charm: JenkinsAgentCharm = harness.charm


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Fixes: #123
<!-- A high level overview of the change -->

### Rationale

- Agent application deployed under same name under different models collide
- Decision for controller: unsupported, likelihood of cross-controller w/ same model names are low.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`trivial`, `senior-review-required`)

<!-- Explanation for any unchecked items above -->
