### PR TITLE
fix: eject pytest async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ lint = [
   "mypy",
   "pep8-naming",
   "pytest",
-  "pytest-asyncio",
   "pytest-operator",
   "ruff",
   "types-pyyaml",
@@ -63,7 +62,6 @@ integration = [
   "juju>=3,<4",
   "protobuf==7.35.0",
   "pytest",
-  "pytest-asyncio",
   "pytest-operator",
 ]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -214,7 +214,7 @@ def jenkins_agent_application_fixture(
         num_units=1,
         base=request.param,
         config={"jenkins_agent_labels": "machine"},
-        constraints={"arch": arch, "virt-type": "virtual-machine"},
+        constraints={"arch": arch},
     )
     juju.wait(jubilant.all_agents_idle, timeout=60 * 20)
     return JENKINS_AGENT_APPLICATION_NAME

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,6 @@ import docker
 import jenkinsapi
 import jubilant
 import pytest
-import pytest_asyncio
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +24,7 @@ JENKINS_AGENT_APPLICATION_NAME = "jenkins-agent"
 ANY_CHARM_APPLICATION_NAME = "any-charm"
 
 
-@pytest_asyncio.fixture(scope="module", name="charm")
+@pytest.fixture(scope="module", name="charm")
 async def charm_fixture(request: pytest.FixtureRequest) -> str:
     """The path to charm."""
     charm = request.config.getoption("--charm-file")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,7 +105,7 @@ def _get_juju_jenkins_server_password(juju: jubilant.Juju, application: str):
 def _deploy_jenkins_server_juju(agent_juju: jubilant.Juju, microk8s_juju: jubilant.Juju):
     """Deploy Jenkins k8s server as agent relation provider."""
     microk8s_juju.deploy(JENKINS_APPLICATION_NAME, channel="latest/edge")
-    microk8s_juju.wait(jubilant.all_active, timeout=60 * 5)
+    microk8s_juju.wait(jubilant.all_active, timeout=60 * 25)
     unit_status = (
         microk8s_juju.status()
         .get_units(JENKINS_APPLICATION_NAME)
@@ -214,9 +214,9 @@ def jenkins_agent_application_fixture(
         num_units=1,
         base=request.param,
         config={"jenkins_agent_labels": "machine"},
-        constraints={"arch": arch},
+        constraints={"arch": arch, "virt-type": "virtual-machine"},
     )
-    juju.wait(jubilant.all_agents_idle, timeout=60 * 15)
+    juju.wait(jubilant.all_agents_idle, timeout=60 * 20)
     return JENKINS_AGENT_APPLICATION_NAME
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,7 @@ ANY_CHARM_APPLICATION_NAME = "any-charm"
 
 
 @pytest.fixture(scope="module", name="charm")
-async def charm_fixture(request: pytest.FixtureRequest) -> str:
+def charm_fixture(request: pytest.FixtureRequest) -> str:
     """The path to charm."""
     charm = request.config.getoption("--charm-file")
     assert charm, "Charm file not provided"
@@ -105,7 +105,7 @@ def _get_juju_jenkins_server_password(juju: jubilant.Juju, application: str):
 def _deploy_jenkins_server_juju(agent_juju: jubilant.Juju, microk8s_juju: jubilant.Juju):
     """Deploy Jenkins k8s server as agent relation provider."""
     microk8s_juju.deploy(JENKINS_APPLICATION_NAME, channel="latest/edge")
-    microk8s_juju.wait(jubilant.all_active)
+    microk8s_juju.wait(jubilant.all_active, timeout=60 * 5)
     unit_status = (
         microk8s_juju.status()
         .get_units(JENKINS_APPLICATION_NAME)

--- a/uv.lock
+++ b/uv.lock
@@ -807,7 +807,6 @@ integration = [
     { name = "juju" },
     { name = "protobuf" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-operator" },
 ]
 lint = [
@@ -819,7 +818,6 @@ lint = [
     { name = "mypy" },
     { name = "pep8-naming" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-operator" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -858,7 +856,6 @@ integration = [
     { name = "juju", specifier = ">=3,<4" },
     { name = "protobuf", specifier = "==7.35.0" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-operator" },
 ]
 lint = [
@@ -870,7 +867,6 @@ lint = [
     { name = "mypy" },
     { name = "pep8-naming" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-operator" },
     { name = "ruff" },
     { name = "types-pyyaml" },


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Eject pytest asyncio from tests
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`trivial`, `senior-review-required`)

<!-- Explanation for any unchecked items above -->
