### PR TITLE
fix: Use recommended args to connect to Jenkins

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-23
+
+- Fix deprecated `-jnlpUrl` argument by using `-url` and `-name` when connecting to Jenkins.
+
 ## 2026-06-15
 
 - Fix issue with agent applications with same name under different models.

--- a/docs/explanation/workload.md
+++ b/docs/explanation/workload.md
@@ -5,7 +5,8 @@ The core Jenkins agent workload requires three main parameters (`JENKINS_URL`, `
 2. Run the agent binary with the following parameters to register the node with Jenkins:
 ```
 /usr/bin/java -jar agent.jar \\
--jnlpUrl "<jnlp-path-on-jenkins-server>" \\
+-url "${JENKINS_URL}" \\
+-name "${JENKINS_AGENT}" \\
 -workDir "${JENKINS_WORKDIR}" \\
 -noReconnect \\
 -secret "${JENKINS_SECRET}"

--- a/templates/jenkins_agent.sh
+++ b/templates/jenkins_agent.sh
@@ -54,7 +54,7 @@ fi
 # Specify the agent as ready
 touch "${JENKINS_HOME}/.ready"
 info "Connecting to jenkins"
-if ! java -jar "${JENKINS_HOME}/agent.jar" -jnlpUrl "${JENKINS_URL}/computer/${JENKINS_AGENT}/slave-agent.jnlp" -workDir "${JENKINS_HOME}" -noReconnect -secret "${JENKINS_TOKEN}"; then
+if ! java -jar "${JENKINS_HOME}/agent.jar" -url "${JENKINS_URL}" -name "${JENKINS_AGENT}" -workDir "${JENKINS_HOME}" -noReconnect -secret "${JENKINS_TOKEN}"; then
     err "Error connecting to jenkins"
     # Remove ready mark if unsuccessful
     rm $JENKINS_HOME/.ready


### PR DESCRIPTION
Applicable spec: <link>

### Overview

* Use the arguments `-url ${JENKINS_URL}` and `-name ${AGENT_NAME}` instead of passing `-jnlpUrl ${JENKINS_URL}/computer/${AGENT_NAME}/jenkinsagent.jnlp` ([upstream change](https://www.jenkins.io/changelog/2.437/#:~:text=8762-,The,8773))

Fixes #122

Verified manually (the warning log disappears)

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`trivial`, `senior-review-required`)

<!-- Explanation for any unchecked items above -->
