### PR TITLE
chore: use gh hosted runners

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,8 +15,6 @@ jobs:
       pre-run-script: tests/integration/setup_microk8s.sh
       juju-channel: 3/stable
       channel: 1.34-strict/edge
-      self-hosted-runner: true
-      self-hosted-runner-label: edge
       with-uv: true
   integration-tests-non-amd64:
     strategy:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Switch over CI to use GitHub hosted runners

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`trivial`, `senior-review-required`)

<!-- Explanation for any unchecked items above -->
