### PR TITLE
refactor: lazily initialize agent state and service

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-08-17
+
+- Initialize agent state and service lazily during reconciliation so invalid
+  configuration can be corrected without restarting the charm process.
+
 ## August 12, 2026
 
 - Harden configurable agent user and home directory handling with validated paths,

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,14 +26,8 @@ class JenkinsAgentCharm(ops.CharmBase):
             args: Arguments to initialize the charm base.
         """
         super().__init__(*args)
-        try:
-            self.state = State.from_charm(self)
-        except InvalidStateError as e:
-            logger.debug("Error parsing charm_state %s", e)
-            self.unit.status = ops.BlockedStatus(e.msg)
-            return
-
-        self.jenkins_agent_service = service.JenkinsAgentService(self.state)
+        self.state = typing.cast(State, None)
+        self.jenkins_agent_service = typing.cast(service.JenkinsAgentService, None)
 
         for event in (
             self.on.install,
@@ -54,6 +48,16 @@ class JenkinsAgentCharm(ops.CharmBase):
         Raises:
             RuntimeError: when installation or service start fails.
         """
+        if self.state is None:
+            try:
+                self.state = State.from_charm(self)
+            except InvalidStateError as exc:
+                logger.debug("Error parsing charm_state %s", exc)
+                self.unit.status = ops.BlockedStatus(exc.msg)
+                return
+        if self.jenkins_agent_service is None:
+            self.jenkins_agent_service = service.JenkinsAgentService(self.state)
+
         self._reconcile_installation()
         self._reconcile_relation_data()
         self._reconcile_service()
@@ -64,6 +68,8 @@ class JenkinsAgentCharm(ops.CharmBase):
         Raises:
             RuntimeError: when the installation of the agent service fails.
         """
+        if self.jenkins_agent_service is None:
+            raise RuntimeError("Agent service is not initialized")
         try:
             self.jenkins_agent_service.install()
         except service.PackageInstallError as exc:
@@ -72,6 +78,8 @@ class JenkinsAgentCharm(ops.CharmBase):
 
     def _reconcile_relation_data(self) -> None:
         """Publish agent metadata to the relation databag when related."""
+        if self.state is None:
+            raise RuntimeError("Agent state is not initialized")
         if agent_relation := self.model.get_relation(AGENT_RELATION):
             agent_relation.data[self.unit].update(self.state.agent_meta.as_dict())
 
@@ -81,6 +89,8 @@ class JenkinsAgentCharm(ops.CharmBase):
         Raises:
             RuntimeError: when the service fails to properly start.
         """
+        if self.jenkins_agent_service is None or self.state is None:
+            raise RuntimeError("Agent state is not initialized")
         agent_service = self.jenkins_agent_service
         if not self.model.get_relation(AGENT_RELATION):
             if agent_service.is_active:

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,9 +26,6 @@ class JenkinsAgentCharm(ops.CharmBase):
             args: Arguments to initialize the charm base.
         """
         super().__init__(*args)
-        self.state = typing.cast(State, None)
-        self.jenkins_agent_service = typing.cast(service.JenkinsAgentService, None)
-
         for event in (
             self.on.install,
             self.on.start,
@@ -48,50 +45,48 @@ class JenkinsAgentCharm(ops.CharmBase):
         Raises:
             RuntimeError: when installation or service start fails.
         """
-        if self.state is None:
-            try:
-                self.state = State.from_charm(self)
-            except InvalidStateError as exc:
-                logger.debug("Error parsing charm_state %s", exc)
-                self.unit.status = ops.BlockedStatus(exc.msg)
-                return
-        if self.jenkins_agent_service is None:
-            self.jenkins_agent_service = service.JenkinsAgentService(self.state)
+        try:
+            state = State.from_charm(self)
+        except InvalidStateError as exc:
+            logger.debug("Error parsing charm_state %s", exc)
+            self.unit.status = ops.BlockedStatus(exc.msg)
+            return
 
-        self._reconcile_installation()
-        self._reconcile_relation_data()
-        self._reconcile_service()
+        agent_service = service.JenkinsAgentService(state)
+        self._reconcile_installation(agent_service)
+        self._reconcile_relation_data(state)
+        self._reconcile_service(state, agent_service)
 
-    def _reconcile_installation(self) -> None:
+    def _reconcile_installation(self, agent_service: service.JenkinsAgentService) -> None:
         """Ensure the agent package and service files are installed and current.
+
+        Args:
+            agent_service: The service built from the current desired state.
 
         Raises:
             RuntimeError: when the installation of the agent service fails.
         """
-        if self.jenkins_agent_service is None:
-            raise RuntimeError("Agent service is not initialized")
         try:
-            self.jenkins_agent_service.install()
+            agent_service.install()
         except service.PackageInstallError as exc:
             logger.error("Error installing the agent service %s", exc)
             raise RuntimeError("Error installing the agent service") from exc
 
-    def _reconcile_relation_data(self) -> None:
+    def _reconcile_relation_data(self, state: State) -> None:
         """Publish agent metadata to the relation databag when related."""
-        if self.state is None:
-            raise RuntimeError("Agent state is not initialized")
         if agent_relation := self.model.get_relation(AGENT_RELATION):
-            agent_relation.data[self.unit].update(self.state.agent_meta.as_dict())
+            agent_relation.data[self.unit].update(state.agent_meta.as_dict())
 
-    def _reconcile_service(self) -> None:
+    def _reconcile_service(self, state: State, agent_service: service.JenkinsAgentService) -> None:
         """Converge the jenkins agent systemd service to the desired state.
+
+        Args:
+            state: The current desired charm state.
+            agent_service: The service built from the current desired state.
 
         Raises:
             RuntimeError: when the service fails to properly start.
         """
-        if self.jenkins_agent_service is None or self.state is None:
-            raise RuntimeError("Agent state is not initialized")
-        agent_service = self.jenkins_agent_service
         if not self.model.get_relation(AGENT_RELATION):
             if agent_service.is_active:
                 try:
@@ -102,7 +97,7 @@ class JenkinsAgentCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus("Waiting for relation.")
             return
 
-        credentials = self.state.agent_relation_credentials
+        credentials = state.agent_relation_credentials
         if not credentials:
             self.unit.status = ops.WaitingStatus("Waiting for complete relation data.")
             logger.info("Waiting for complete relation data.")

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -13,6 +13,7 @@ import ops
 import ops.testing
 import pytest
 
+import charm_state
 import service
 from charm_state import AGENT_RELATION
 
@@ -36,7 +37,7 @@ def test_agent_relation_joined_sets_databag(
     charm: JenkinsAgentCharm = harness.charm
     assert (
         harness.get_relation_data(relation_id, app_or_unit="jenkins-agent/0")
-        == charm.state.agent_meta.as_dict()
+        == charm_state.State.from_charm(charm).agent_meta.as_dict()
     )
 
 
@@ -56,12 +57,10 @@ def test_agent_relation_changed_restarts_service(
     charm: JenkinsAgentCharm = harness.charm
     charm.on.config_changed.emit()
 
-    assert charm.state.agent_relation_credentials
-    assert (
-        charm.state.agent_relation_credentials.secret
-        == agent_relation_data["test-model-jenkins-agent-0_secret"]
-    )
-    assert charm.state.agent_relation_credentials.address == agent_relation_data["url"]
+    credentials = charm_state.State.from_charm(charm).agent_relation_credentials
+    assert credentials
+    assert credentials.secret == agent_relation_data["test-model-jenkins-agent-0_secret"]
+    assert credentials.address == agent_relation_data["url"]
     assert service_mocks.restart.call_count == 1
     assert charm.unit.status.name == ops.ActiveStatus.name
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,7 @@
 
 """Test for charm reconcile handler."""
 
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, PropertyMock
@@ -140,7 +141,10 @@ def test_reconcile_incomplete_credentials_waiting(
     harness.charm.on.install.emit()
 
     charm: JenkinsAgentCharm = harness.charm
-    monkeypatch.setattr(charm.state, "agent_relation_credentials", None)
+    incomplete_state = replace(
+        charm_state.State.from_charm(charm), agent_relation_credentials=None
+    )
+    monkeypatch.setattr(charm_state.State, "from_charm", lambda charm: incomplete_state)
     charm.on.update_status.emit()
 
     assert charm.unit.status.name == ops.WaitingStatus.name
@@ -202,7 +206,7 @@ def test_reconcile_config_changed_updates_databag(
 
     assert (
         harness.get_relation_data(relation.id, app_or_unit="jenkins-agent/0")
-        == charm.state.agent_meta.as_dict()
+        == charm_state.State.from_charm(charm).agent_meta.as_dict()
     )
 
 
@@ -218,6 +222,5 @@ def test_invalid_initial_state_recovers_after_config_change(
 
     harness.update_config({"agent_user": "jenkins"})
 
-    assert harness.charm.state is not None
-    assert harness.charm.jenkins_agent_service is not None
+    assert charm_state.State.from_charm(harness.charm) is not None
     assert harness.charm.unit.status.message == "Waiting for relation."

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,13 +26,14 @@ def test___init___invalid_state(harness: ops.testing.Harness, monkeypatch: pytes
     act: when the JenkinsAgentCharm is initialized.
     assert: The agent falls into BlockedStatus.
     """
-    monkeypatch.setattr(
-        charm_state.State,
-        "from_charm",
-        MagicMock(side_effect=[charm_state.InvalidStateError("Invalid executor message")]),
-    )
+
+    def invalid_state(_charm):
+        raise charm_state.InvalidStateError("Invalid executor message")
+
+    monkeypatch.setattr(charm_state.State, "from_charm", MagicMock(side_effect=invalid_state))
 
     harness.begin()
+    harness.charm.on.install.emit()
 
     charm: JenkinsAgentCharm = harness.charm
     assert charm.unit.status.name == ops.BlockedStatus.name
@@ -136,6 +137,7 @@ def test_reconcile_incomplete_credentials_waiting(
     """
     harness = harness_with_agent_relation
     harness.begin()
+    harness.charm.on.install.emit()
 
     charm: JenkinsAgentCharm = harness.charm
     monkeypatch.setattr(charm.state, "agent_relation_credentials", None)
@@ -202,3 +204,20 @@ def test_reconcile_config_changed_updates_databag(
         harness.get_relation_data(relation.id, app_or_unit="jenkins-agent/0")
         == charm.state.agent_meta.as_dict()
     )
+
+
+def test_invalid_initial_state_recovers_after_config_change(
+    harness: ops.testing.Harness,
+    service_mocks: SimpleNamespace,
+):
+    """Lazy state initialization allows an invalid config to be corrected."""
+    harness.update_config({"agent_user": "bad/user"})
+    harness.begin()
+    harness.charm.on.install.emit()
+    assert harness.charm.unit.status.name == ops.BlockedStatus.name
+
+    harness.update_config({"agent_user": "jenkins"})
+
+    assert harness.charm.state is not None
+    assert harness.charm.jenkins_agent_service is not None
+    assert harness.charm.unit.status.message == "Waiting for relation."

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -31,14 +31,15 @@ if TYPE_CHECKING:
 
 
 def _begin_with_lazy_service(harness: ops.testing.Harness, *, run_install: bool = False) -> None:
-    """Initialize lazy charm state, optionally running the install hook."""
+    """Run a minimal hook so lazy charm state/service initialization occurs."""
     harness.begin()
-    if harness.charm.state is None:
-        harness.charm.state = charm_state.State.from_charm(harness.charm)
-    if harness.charm.jenkins_agent_service is None:
-        harness.charm.jenkins_agent_service = service.JenkinsAgentService(harness.charm.state)
     if run_install:
         harness.charm.on.install.emit()
+
+
+def _service(harness: ops.testing.Harness) -> service.JenkinsAgentService:
+    """Build the service from the charm's current desired state for direct tests."""
+    return service.JenkinsAgentService(charm_state.State.from_charm(harness.charm))
 
 
 def _mock_install_host(
@@ -485,9 +486,7 @@ def test_restart_service(
 def test_restart_template_preserves_systemd_values(harness: ops.testing.Harness):
     """Systemd templates must not HTML-escape credentials or URLs."""
     _begin_with_lazy_service(harness)
-    template = harness.charm.jenkins_agent_service._template_loader.get_template(
-        "jenkins_agent_env.conf.j2"
-    )
+    template = _service(harness)._template_loader.get_template("jenkins_agent_env.conf.j2")
 
     rendered = template.render(
         environments={"JENKINS_TOKEN": 'a&b<c>"d', "JENKINS_URL": "https://jenkins.test"}
@@ -510,13 +509,12 @@ def test_restart_service_write_config_type_error(
     monkeypatch.setattr(Path, "mkdir", MagicMock)
     harness.add_relation(AGENT_RELATION, "jenkins-k8s", unit_data=agent_relation_data)
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(
         service.ServiceRestartError,
         match=r"Error interacting with the filesystem when rendering configuration file",
     ):
-        charm.jenkins_agent_service.restart()
+        _service(harness).restart()
 
 
 def test_restart_service_systemd_error(
@@ -537,13 +535,12 @@ def test_restart_service_systemd_error(
     )
     harness.add_relation(AGENT_RELATION, "jenkins-k8s", unit_data=agent_relation_data)
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(
         service.ServiceRestartError,
         match=rf"Error starting the agent service:\n{systemd_error_message}",
     ):
-        charm.jenkins_agent_service.restart()
+        _service(harness).restart()
 
 
 def test_service_is_active_systemd_error(
@@ -566,9 +563,8 @@ def test_service_is_active_systemd_error(
 
     monkeypatch.setattr(Path, "exists", _mock_exists)
     monkeypatch.setattr(systemd, "service_running", MagicMock(side_effect=SystemError))
-    charm: JenkinsAgentCharm = harness.charm
 
-    assert not charm.jenkins_agent_service.is_active
+    assert not _service(harness).is_active
 
 
 def test_parse_systemd_env():
@@ -657,8 +653,7 @@ def test_credentials_changed(
         unit_data={"url": cred_url, "test-model-jenkins-agent-0_secret": cred_secret},
     )
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
-    result = charm.jenkins_agent_service.credentials_changed(
+    result = _service(harness).credentials_changed(
         Credentials(address=cred_url, secret=cred_secret)
     )
     assert result is expected
@@ -672,10 +667,9 @@ def test_restart_missing_credentials(harness: ops.testing.Harness):
     """
     # The default harness has no agent relation, so credentials resolve to None.
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(service.ServiceRestartError, match=r"missing configuration"):
-        charm.jenkins_agent_service.restart()
+        _service(harness).restart()
 
 
 def test_restart_startup_check_timeout(
@@ -696,12 +690,11 @@ def test_restart_startup_check_timeout(
     monkeypatch.setattr(service.time, "sleep", MagicMock())
     harness.add_relation(AGENT_RELATION, "jenkins-k8s", unit_data=agent_relation_data)
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(
         service.ServiceRestartError, match=r"waiting for the agent service to start"
     ):
-        charm.jenkins_agent_service.restart()
+        _service(harness).restart()
 
 
 def test_startup_check_becomes_active(
@@ -715,9 +708,8 @@ def test_startup_check_becomes_active(
     monkeypatch.setattr(service.JenkinsAgentService, "is_active", PropertyMock(return_value=True))
     monkeypatch.setattr(service.time, "sleep", MagicMock())
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
-    assert charm.jenkins_agent_service._startup_check() is True
+    assert _service(harness)._startup_check() is True
 
 
 def test_reset_failed_state_logs_on_error(
@@ -730,10 +722,9 @@ def test_reset_failed_state_logs_on_error(
     """
     monkeypatch.setattr(systemd, "_systemctl", MagicMock(side_effect=systemd.SystemdError))
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
     # Should not raise.
-    charm.jenkins_agent_service.reset_failed_state()
+    _service(harness).reset_failed_state()
 
 
 def test_reset_stops_and_clears_config(
@@ -752,9 +743,8 @@ def test_reset_stops_and_clears_config(
     stop_mock = MagicMock()
     monkeypatch.setattr(systemd, "service_stop", stop_mock)
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
-    charm.jenkins_agent_service.reset()
+    _service(harness).reset()
 
     assert stop_mock.call_count == 1
     assert not override.exists()
@@ -768,10 +758,9 @@ def test_reset_stop_error(harness: ops.testing.Harness, monkeypatch: pytest.Monk
     """
     monkeypatch.setattr(systemd, "service_stop", MagicMock(side_effect=systemd.SystemdError))
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(service.ServiceStopError, match=r"failed to stop"):
-        charm.jenkins_agent_service.reset()
+        _service(harness).reset()
 
 
 def test_sync_service_files_read_error(
@@ -797,7 +786,6 @@ def test_sync_service_files_read_error(
 
     monkeypatch.setattr(Path, "read_text", _read_text)
     _begin_with_lazy_service(harness)
-    charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(service.FileRenderError, match=r"Error reading file"):
-        charm.jenkins_agent_service.install()
+        _service(harness).install()

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -22,11 +22,23 @@ import pytest
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import systemd
 
+import charm_state
 import service
 from charm_state import AGENT_RELATION, Credentials
 
 if TYPE_CHECKING:
     from charm import JenkinsAgentCharm
+
+
+def _begin_with_lazy_service(harness: ops.testing.Harness, *, run_install: bool = False) -> None:
+    """Initialize lazy charm state, optionally running the install hook."""
+    harness.begin()
+    if harness.charm.state is None:
+        harness.charm.state = charm_state.State.from_charm(harness.charm)
+    if harness.charm.jenkins_agent_service is None:
+        harness.charm.jenkins_agent_service = service.JenkinsAgentService(harness.charm.state)
+    if run_install:
+        harness.charm.on.install.emit()
 
 
 def _mock_install_host(
@@ -103,7 +115,7 @@ def test_install_apt_package_gpg_key_error(
     assert: The charm should be in an error state.
     """
     _mock_install_host(monkeypatch, tmp_path)
-    harness.begin()
+    _begin_with_lazy_service(harness, run_install=True)
     charm: JenkinsAgentCharm = harness.charm
     monkeypatch.setattr(apt, "add_package", MagicMock())
     monkeypatch.setattr(apt, f, MagicMock(side_effect=[error_thrown]))
@@ -122,7 +134,7 @@ def test_on_install(harness: ops.testing.Harness, monkeypatch: pytest.MonkeyPatc
     host = _mock_install_host(monkeypatch, tmp_path)
     monkeypatch.setattr(apt, "add_package", apt_add_package_mock)
 
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
 
     # The package is absent (mock always raises), so every reconcile installs it
     # with the expected package list.
@@ -147,7 +159,7 @@ def test_install_skips_apt_when_package_present(
     _mock_install_host(monkeypatch, tmp_path, package_installed=True)
     monkeypatch.setattr(apt, "add_package", apt_add_package_mock)
 
-    harness.begin()
+    _begin_with_lazy_service(harness, run_install=True)
     harness.charm.on.install.emit()
 
     assert apt_add_package_mock.call_count == 0
@@ -162,7 +174,7 @@ def test_install_skips_reload_when_unit_unchanged(
     assert: the second run does not reload or re-enable the unchanged unit file.
     """
     host = _mock_install_host(monkeypatch, tmp_path, package_installed=True)
-    harness.begin()
+    _begin_with_lazy_service(harness, run_install=True)
 
     harness.charm.on.install.emit()
     first_enable_count = host.service_enable.call_count
@@ -183,7 +195,7 @@ def test_install_enable_error(
     """
     host = _mock_install_host(monkeypatch, tmp_path)
     host.service_enable.side_effect = systemd.SystemdError("boom")
-    harness.begin()
+    _begin_with_lazy_service(harness)
 
     with pytest.raises(RuntimeError, match=r"Error installing the agent service"):
         harness.charm.on.install.emit()
@@ -202,7 +214,7 @@ def test_install_renders_user_and_workdir(
     apt_add_package_mock = MagicMock()
     monkeypatch.setattr(apt, "add_package", apt_add_package_mock)
 
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
     unit_text = host.unit_path.read_text()
 
     assert "User=jenkins" in unit_text
@@ -226,7 +238,7 @@ def test_install_renders_custom_user_and_workdir(
     monkeypatch.setattr(apt, "add_package", apt_add_package_mock)
 
     harness.update_config({"agent_user": "jenkins", "jenkins_home": "/srv/jenkins"})
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
     unit_text = host.unit_path.read_text()
 
     assert "User=jenkins" in unit_text
@@ -249,7 +261,7 @@ def test_install_renders_script_with_jenkins_home(
     monkeypatch.setattr(apt, "add_package", apt_add_package_mock)
 
     harness.update_config({"jenkins_home": "/srv/jenkins"})
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
     script_text = Path(host.script_path).read_text()
 
     assert 'JENKINS_HOME="${JENKINS_HOME:-/srv/jenkins}"' in script_text
@@ -267,7 +279,7 @@ def test_install_renders_script_with_default_jenkins_home(
     apt_add_package_mock = MagicMock()
     monkeypatch.setattr(apt, "add_package", apt_add_package_mock)
 
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
     script_text = Path(host.script_path).read_text()
 
     assert 'JENKINS_HOME="${JENKINS_HOME:-/var/lib/jenkins}"' in script_text
@@ -292,7 +304,7 @@ def test_install_creates_user_and_home(
     monkeypatch.setattr(os, "chown", chown_mock)
 
     harness.update_config({"agent_user": "jenkins", "jenkins_home": str(home)})
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
 
     assert home.exists()
     jenkins_uid = pwd.getpwnam("jenkins").pw_uid
@@ -320,7 +332,7 @@ def test_install_fails_on_useradd_failure(
 
     harness.update_config({"agent_user": username, "jenkins_home": str(home)})
     with pytest.raises(RuntimeError, match=r"Error installing the agent service"):
-        harness.begin_with_initial_hooks()
+        _begin_with_lazy_service(harness, run_install=True)
 
 
 def _make_fake_useradd(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -379,7 +391,7 @@ def test_render_file_uses_configured_owner(
     monkeypatch.setattr(os, "chown", chown_mock)
 
     harness.update_config({"agent_user": "jenkins", "jenkins_home": str(home)})
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
 
     jenkins_uid = pwd.getpwnam("jenkins").pw_uid
     jenkins_gid = pwd.getpwnam("jenkins").pw_gid
@@ -407,7 +419,7 @@ def test_ensure_user_does_not_chown_existing_home_contents(
     monkeypatch.setattr(os, "chown", chown_mock)
 
     harness.update_config({"agent_user": "jenkins", "jenkins_home": str(home)})
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
 
     jenkins_uid = pwd.getpwnam("jenkins").pw_uid
     jenkins_gid = pwd.getpwnam("jenkins").pw_gid
@@ -428,7 +440,7 @@ def test_install_grants_passwordless_sudo(
     monkeypatch.setattr(service, "SUDOERS_DROP_IN_DIR", sudoers_d)
 
     harness.update_config({"agent_user": "jenkins", "jenkins_home": str(home)})
-    harness.begin_with_initial_hooks()
+    _begin_with_lazy_service(harness, run_install=True)
 
     drop_in_path = sudoers_d / "99-jenkins-agent"
     assert drop_in_path.read_text() == "jenkins ALL=(ALL:ALL) NOPASSWD: ALL\n"
@@ -462,7 +474,7 @@ def test_restart_service(
     monkeypatch.setattr(service.JenkinsAgentService, "install", MagicMock())
 
     harness.add_relation(AGENT_RELATION, "jenkins-k8s", unit_data=agent_relation_data)
-    harness.begin()
+    _begin_with_lazy_service(harness, run_install=True)
     charm: JenkinsAgentCharm = harness.charm
     charm.on.config_changed.emit()
 
@@ -472,7 +484,7 @@ def test_restart_service(
 
 def test_restart_template_preserves_systemd_values(harness: ops.testing.Harness):
     """Systemd templates must not HTML-escape credentials or URLs."""
-    harness.begin()
+    _begin_with_lazy_service(harness)
     template = harness.charm.jenkins_agent_service._template_loader.get_template(
         "jenkins_agent_env.conf.j2"
     )
@@ -497,7 +509,7 @@ def test_restart_service_write_config_type_error(
     monkeypatch.setattr(Path, "write_text", MagicMock(side_effect=TypeError))
     monkeypatch.setattr(Path, "mkdir", MagicMock)
     harness.add_relation(AGENT_RELATION, "jenkins-k8s", unit_data=agent_relation_data)
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(
@@ -524,7 +536,7 @@ def test_restart_service_systemd_error(
         MagicMock(side_effect=systemd.SystemdError(systemd_error_message)),
     )
     harness.add_relation(AGENT_RELATION, "jenkins-k8s", unit_data=agent_relation_data)
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(
@@ -542,7 +554,7 @@ def test_service_is_active_systemd_error(
     act: Check if the service is running.
     assert: The call should return false and not raising any exceptions.
     """
-    harness.begin()
+    _begin_with_lazy_service(harness)
     # Mock Path.exists to return True for AGENT_READY_PATH so we exercise the
     # systemd.service_running path.
     real_exists = Path.exists
@@ -644,7 +656,7 @@ def test_credentials_changed(
         "jenkins-k8s",
         unit_data={"url": cred_url, "test-model-jenkins-agent-0_secret": cred_secret},
     )
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
     result = charm.jenkins_agent_service.credentials_changed(
         Credentials(address=cred_url, secret=cred_secret)
@@ -659,7 +671,7 @@ def test_restart_missing_credentials(harness: ops.testing.Harness):
     assert: ServiceRestartError is raised for the missing configuration.
     """
     # The default harness has no agent relation, so credentials resolve to None.
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(service.ServiceRestartError, match=r"missing configuration"):
@@ -683,7 +695,7 @@ def test_restart_startup_check_timeout(
     monkeypatch.setattr(service, "STARTUP_CHECK_TIMEOUT", 0)
     monkeypatch.setattr(service.time, "sleep", MagicMock())
     harness.add_relation(AGENT_RELATION, "jenkins-k8s", unit_data=agent_relation_data)
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(
@@ -702,7 +714,7 @@ def test_startup_check_becomes_active(
     """
     monkeypatch.setattr(service.JenkinsAgentService, "is_active", PropertyMock(return_value=True))
     monkeypatch.setattr(service.time, "sleep", MagicMock())
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     assert charm.jenkins_agent_service._startup_check() is True
@@ -717,7 +729,7 @@ def test_reset_failed_state_logs_on_error(
     assert: the error is swallowed (logged, not raised) as it is non-critical.
     """
     monkeypatch.setattr(systemd, "_systemctl", MagicMock(side_effect=systemd.SystemdError))
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     # Should not raise.
@@ -739,7 +751,7 @@ def test_reset_stops_and_clears_config(
     monkeypatch.setattr(service, "SYSTEMD_SERVICE_CONF_DIR", str(config_dir))
     stop_mock = MagicMock()
     monkeypatch.setattr(systemd, "service_stop", stop_mock)
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     charm.jenkins_agent_service.reset()
@@ -755,7 +767,7 @@ def test_reset_stop_error(harness: ops.testing.Harness, monkeypatch: pytest.Monk
     assert: ServiceStopError is raised.
     """
     monkeypatch.setattr(systemd, "service_stop", MagicMock(side_effect=systemd.SystemdError))
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(service.ServiceStopError, match=r"failed to stop"):
@@ -784,7 +796,7 @@ def test_sync_service_files_read_error(
         return real_read_text(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "read_text", _read_text)
-    harness.begin()
+    _begin_with_lazy_service(harness)
     charm: JenkinsAgentCharm = harness.charm
 
     with pytest.raises(service.FileRenderError, match=r"Error reading file"):


### PR DESCRIPTION
## Summary
- Remove state and service initialization from `__init__`.
- Initialize both lazily from the common reconcile path.
- Keep event observers registered when configuration is initially invalid so a later valid configuration can recover.
- Add recovery coverage and document the lifecycle change.

## Test plan
- `uv run tox run -e unit`
- `uv run tox run -e lint`
